### PR TITLE
Allow for `fizzbuzz` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Usage
 var fizzbuzz = require('fizz-buzz');
 
 fizzbuzz([1,2,3,4,5]) // [ 1, 2, 'fizz', 4, 'buzz' ]
-fizzbuzz([10,11,12,13,14,15]) // [ 'buzz', 11, 'fizz', 13, 14, 'fizz' ]
+fizzbuzz([10,11,12,13,14,15]) // [ 'buzz', 11, 'fizz', 13, 14, 'fizzbuzz' ]
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,22 +1,23 @@
 /**
-* Determines if an array contains numbers divisibly by 3 or 5.
-*
-* @param {array} array Array of numbers
-* @returns {array} arr Returns array of numbers
-*
-*/
+ * Determines if an array contains numbers divisibly by 3 or 5.
+ *
+ * @param {array} array Array of numbers
+ * @returns {array} arr Returns array of numbers
+ *
+ */
 
 function fizzBuzzArr(array) {
   var arr = array.slice();
   return arr.map(function(item) {
-    return _fizzBuzz(item) ? _fizzBuzz(item) : item;
+    return _fizzBuzz(item);
   });
 }
 
 function _fizzBuzz(number) {
-  if(number % 3 == 0) { return "fizz"; }
-  else if(number % 5 == 0) { return "buzz"; }
-  else return false;
+  let str = ''
+  if (number % 3 == 0) { str += "fizz"; }
+  if (number % 5 == 0) { str += "buzz"; }
+  return str || number;
 }
 
 module.exports = fizzBuzzArr;


### PR DESCRIPTION
In the original task umbers divisible by both 3 and 5 were supposed to return 'fizzbuzz'.